### PR TITLE
Mozliwosc tworzenia dowolnych odmian walut, ktore ladowane sa dynamic…

### DIFF
--- a/LiczbyNaSlowaNET/Algorithm.cs
+++ b/LiczbyNaSlowaNET/Algorithm.cs
@@ -3,13 +3,18 @@ using System.Collections.Generic;
 
 namespace LiczbyNaSlowaNET
 {
-    abstract class Algorithm : IAlgorithm
+    internal abstract class Algorithm : IAlgorithm
     {
         public IDictionaries Dictionaries { get; set; }
 
         public IEnumerable<int> Numbers { get; set; }
 
         public NumberToTextOptions Options { get; set; }
+
+        protected Algorithm(IDictionaries dictionary)
+        {
+            this.Dictionaries = dictionary;
+        }
 
         public abstract string Build();
 

--- a/LiczbyNaSlowaNET/Algorithms/CommonAlgorithm.cs
+++ b/LiczbyNaSlowaNET/Algorithms/CommonAlgorithm.cs
@@ -8,6 +8,11 @@ namespace LiczbyNaSlowaNET
 {
     internal sealed class CommonAlgorithm : Algorithm
     {
+        public CommonAlgorithm(IDictionaries dictionary) :
+           base(dictionary)
+        {
+
+        }
         private StringBuilder result = new StringBuilder();
 
         private int hundreds;

--- a/LiczbyNaSlowaNET/Algorithms/CurrencyAlgorithm.cs
+++ b/LiczbyNaSlowaNET/Algorithms/CurrencyAlgorithm.cs
@@ -1,6 +1,7 @@
 ﻿
 // Copyright (c) 2014 Przemek Walkowski
 
+using LiczbyNaSlowaNET.Currencies;
 using System.Linq;
 using System.Text;
 
@@ -8,6 +9,10 @@ namespace LiczbyNaSlowaNET
 {
     internal sealed class CurrencyAlgorithm : Algorithm
     {
+        public CurrencyAlgorithm(IDictionaries dictionary) :
+           base(dictionary)
+        { }
+
         private StringBuilder result = new StringBuilder();
        
         private int hundreds;
@@ -40,7 +45,7 @@ namespace LiczbyNaSlowaNET
                     partialResult.Append(Dictionaries.Unity[10]).ToString();
                     partialResult.Append(" ");
 
-                    partialResult.Append(Dictionaries.Current[(int)currentPhase, 2]).ToString();
+                    partialResult.Append(this.Options.Currency.GetDeflationTable[(int)currentPhase, 2]).ToString();
 
                     result.Append(partialResult.ToString().Trim());
 
@@ -88,12 +93,21 @@ namespace LiczbyNaSlowaNET
                         var tempPartialResult = partialResult.ToString().Trim();
 
                         partialResult.Clear();
+                        var properUnity = Dictionaries.Unity;
+                        if (currentPhase == phase.afterComma && this.Options.Currency is ICurrencyNotMaleDeflectionAfterComma && this.tens == 0)
+                        {
+                            properUnity = (this.Options.Currency as ICurrencyNotMaleDeflectionAfterComma).OverrideAfterCommaUnity;
+                        }
+                        if (currentPhase == phase.beforeComma && this.Options.Currency is ICurrencyNotMaleDeflectionBeforeComma)
+                        {
+                            properUnity = (this.Options.Currency as ICurrencyNotMaleDeflectionBeforeComma).OverrideBeforeCommaUnity;
+                        }
 
                         partialResult.AppendFormat("{0}{1}{2}{3}{4}{5}",
                             this.CheckWhitespace(Dictionaries.Hundreds[this.hundreds]),
                             this.CheckWhitespace(Dictionaries.Tens[this.tens]),
                             this.CheckWhitespace(Dictionaries.OthersTens[this.othersTens]),
-                            this.CheckWhitespace(Dictionaries.Unity[this.unity]),
+                            this.CheckWhitespace(properUnity[this.unity]),
                             this.CheckWhitespace(Dictionaries.Endings[this.order, grammarForm]),
                             this.CheckWhitespace(tempPartialResult));
                     }
@@ -103,7 +117,7 @@ namespace LiczbyNaSlowaNET
                     tempNumber = tempNumber / 1000;
                 }
 
-                partialResult.Append(this.CheckWhitespace(Dictionaries.Current[(int)this.currentPhase, GetCurrencyForm(number)]));
+                partialResult.Append(this.CheckWhitespace(this.Options.Currency.GetDeflationTable[(int)this.currentPhase, GetCurrencyForm(number)]));
 
                 result.Append(partialResult.ToString().Trim());
 

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/ChfCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/ChfCurrencyDeflation.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class ChfCurrencyDeflation : ICurrencyDeflation
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get { return "CHF"; }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new[,]
+                    {
+                    {"", "", ""},
+                    {"frank szwajcarski", "franki szwajcarskie", "franków szwajcarskich"},
+                    {"centym", "centymy", "centymów"}
+                };
+                }
+                else
+                {
+                    return new[,]
+                {
+                    {"", "", ""},
+                    {"frank szwajcarski", "franki szwajcarskie", "frankow szwajcarskich"},
+                    {"centym", "centymy", "centymow"}
+                };
+                }
+            }
+        }
+
+        public List<string> OverrideUnity
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/CurrencyDeflationFactory.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/CurrencyDeflationFactory.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class CurrencyDeflationFactory : ICurrencyDeflationFactory
+    {
+        private readonly List<string> _availableCurrencyDeflations = new List<string>();
+        private bool withStems;
+        public CurrencyDeflationFactory(List<ICurrencyDeflation> definedDeflations,bool withStems)
+        {
+            CurrencyList = definedDeflations;
+            this.withStems = withStems;
+        }
+
+        public List<string> AvailableCurrencyDeflations
+        {
+            get
+            {
+                _availableCurrencyDeflations.Clear();
+                foreach (var item in CurrencyList)
+                {
+                    _availableCurrencyDeflations.Add(item.CurrencyCode);
+                }
+                return _availableCurrencyDeflations;
+            }
+        }
+
+        public List<ICurrencyDeflation> CurrencyList { get; }
+
+        public ICurrencyDeflation CreateInstance(string currencyCode)
+        {
+            var currencyInstance = CurrencyList.Find(x => x.CurrencyCode.Equals(currencyCode));
+            currencyInstance.HasStems = this.withStems;
+            return currencyInstance;
+        }
+ 
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/CzkCurrenctDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/CzkCurrenctDeflation.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class CzkCurrenctDeflation : ICurrencyDeflation, ICurrencyNotMaleDeflectionBeforeComma
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get
+            {
+                return "CZK";
+            }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                return new[,]
+               {
+                    {"", "", ""},
+                    {"korona czeska", "korony czeskie", "koron czeskich"},
+                    {"halerz", "halerze", "halerzy"}
+                };
+            }
+        }
+
+        public List<string> OverrideBeforeCommaUnity
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new List<string>
+                {
+                    "","jedna","dwie" , "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć","zero"
+                };
+                }
+                else
+                {
+                    return new List<string>
+                {
+                    "","jedna","dwie" , "trzy", "cztery", "piec", "szesc", "siedem", "osiem", "dziewiec","zero"
+                };
+                }
+            }
+        }
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/EmptyCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/EmptyCurrencyDeflation.cs
@@ -1,0 +1,52 @@
+﻿using Ninject;
+using System;
+using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class EmptyCurrencyDeflation : ICurrencyDeflation
+    {
+        bool hasStems;
+        public EmptyCurrencyDeflation()
+        { 
+        }
+        public string CurrencyCode
+        {
+            get { return string.Empty; }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                return new[,]
+                {
+                    {"", "", ""},
+                    {"", "", ""},
+                    {"", "", ""}
+                };
+            }
+        }
+
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+
+        public List<string> OverrideUnity
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/EurCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/EurCurrencyDeflation.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class EurCurrencyDeflation : ICurrencyDeflation
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get { return "EUR"; }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new[,]
+                    {
+                    {"", "", ""},
+                    {"euro", "euro", "euro"},
+                    {"cent", "centy", "centów"}
+                };
+                }
+                else
+                {
+                    return new[,]
+                                       {
+                    {"", "", ""},
+                    {"euro", "euro", "euro"},
+                    {"cent", "centy", "centow"}
+                };
+                }
+            }
+        }
+
+        public List<string> OverrideUnity
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/GbpCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/GbpCurrencyDeflation.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class GbpCurrencyDeflation : ICurrencyDeflation
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get
+            {
+                return "GBP";
+            }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new[,]
+                   {
+                    {"", "", ""},
+                    {"funt brytyjski", "funty brytyjskie", "funtów brytyjskich"},
+                    {"pens", "pensy", "pensów"}
+                };
+                }
+                else
+                {
+                    return new[,]
+                                     {
+                    {"", "", ""},
+                    {"funt brytyjski", "funty brytyjskie", "funtow brytyjskich"},
+                    {"pens", "pensy", "pensow"}
+                };
+                }
+            }
+        }
+
+        public List<string> OverrideUnity
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/HufCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/HufCurrencyDeflation.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class HufCurrencyDeflation : ICurrencyDeflation
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get
+            {
+                return "HUF";
+            }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                if(HasStems)
+                {
+                    return new[,]
+                                  {
+                    {"", "", ""},
+                    {"forint", "forinty", "forintów"},
+                    {"", "", ""}
+                };
+                }
+                else
+                {
+                    return new[,]
+                                {
+                    {"", "", ""},
+                    {"forint", "forinty", "forintow"},
+                    {"", "", ""}
+                };
+                }
+                
+            }
+        }
+
+        public List<string> OverrideUnity
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/ICurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/ICurrencyDeflation.cs
@@ -1,0 +1,20 @@
+﻿namespace LiczbyNaSlowaNET.Currencies
+{
+    /// <summary>
+    ///     Interface for classes that define deflation table for specific currency.
+    /// </summary>
+    public interface ICurrencyDeflation
+    {
+        /// <summary>
+        ///     Current currency code as stands in ISO 4217
+        /// </summary>
+        string CurrencyCode { get; }
+
+        /// <summary>
+        ///     Deflation table used during conversion.
+        /// </summary>
+        string[,] GetDeflationTable { get; } 
+        bool HasStems { get; set; }
+
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/ICurrencyDeflationFactory.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/ICurrencyDeflationFactory.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    /// <summary>
+    ///     Interface for classes that define factory able to create currency defaltion instances.
+    /// </summary>
+    public interface ICurrencyDeflationFactory
+    {
+        List<ICurrencyDeflation> CurrencyList { get; }
+        List<string> AvailableCurrencyDeflations { get; }
+        ICurrencyDeflation CreateInstance(string currencyCode); 
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/ICurrencyNotMaleDeflectionAfterComma.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/ICurrencyNotMaleDeflectionAfterComma.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public interface ICurrencyNotMaleDeflectionAfterComma
+    {
+        List<String> OverrideAfterCommaUnity { get; }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/ICurrencyNotMaleDeflectionBeforeComma.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/ICurrencyNotMaleDeflectionBeforeComma.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public interface ICurrencyNotMaleDeflectionBeforeComma
+    {
+        List<String> OverrideBeforeCommaUnity { get; }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/JpyCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/JpyCurrencyDeflation.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class JpyCurrencyDeflation : ICurrencyDeflation
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get
+            {
+                return "JPY";
+            }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new[,]
+                   {
+                    {"", "", ""},
+                    {"jen", "jeny", "jenów"},
+                    {"", "", ""}
+                };
+                }
+                else
+                {
+                    return new[,]
+                   {
+                    {"", "", ""},
+                    {"jen", "jeny", "jenow"},
+                    {"", "", ""}
+                };
+                }
+            }
+        }
+
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+
+        public List<string> OverrideUnity
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/LtlCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/LtlCurrencyDeflation.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class LtlCurrencyDeflation : ICurrencyDeflation
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get
+            {
+                return "LTL";
+            }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new[,]
+                    {
+                    {"", "", ""},
+                    {"lit litewski", "lity litewskie", "litów litewskich"},
+                    {"cent", "centy", "centów"}
+                };
+                }
+                else
+                {
+                    return new[,]
+                   {
+                    {"", "", ""},
+                    {"lit litewski", "lity litewskie", "litow litewskich"},
+                    {"cent", "centy", "centow"}
+                };
+                }
+            }
+        }
+
+        public List<string> OverrideUnity
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/NokCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/NokCurrencyDeflation.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class NokCurrencyDeflation : ICurrencyDeflation, ICurrencyNotMaleDeflectionBeforeComma
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get
+            {
+                return "NOK";
+            }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                return new[,]
+             {
+                    {"", "", ""},
+                    {"korona norweska", "korony norweskie", "koron norweskich"},
+                    {"øre", "øre", "øre"}
+                };
+            }
+        }
+
+        public List<string> OverrideBeforeCommaUnity
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new List<string>
+                {
+                    "","jedna","dwie" , "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć","zero"
+                };
+                }
+                else
+                {
+                    return new List<string>
+                {
+                    "","jedna","dwie" , "trzy", "cztery", "piec", "szesc", "siedem", "osiem", "dziewiec","zero"
+                };
+                }
+            }
+        }
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/PercentageDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/PercentageDeflation.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class PercentageDeflation : ICurrencyDeflation, ICurrencyNotMaleDeflectionAfterComma
+    {
+        private bool hasStems;
+
+        public string CurrencyCode => "%";
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                return new[,]
+                {
+                    {"", "", ""},
+                    {"procent", "procenty", "procent"},
+                    {"setna procenta", "setne procenta", "setnych procenta"}
+                };
+            }
+        }
+
+        public List<string> OverrideAfterCommaUnity
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new List<string>
+                {
+                    "","jedna","dwie" , "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć","zero"
+                };
+                }
+                else
+                {
+                    return new List<string>
+                {
+                    "","jedna","dwie" , "trzy", "cztery", "piec", "szesc", "siedem", "osiem", "dziewiec","zero"
+                };
+                }
+            }
+        }
+
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/PlnCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/PlnCurrencyDeflation.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class PlnCurrencyDeflation : ICurrencyDeflation
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get { return "PLN"; }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new[,]
+                    {
+                    {"", "", ""},
+                    {"złoty", "złote", "złotych"},
+                    {"grosz", "grosze", "groszy"}
+                };
+                }
+                else
+                {
+                    return new[,]
+                  {
+                    {"", "", ""},
+                    {"zloty", "zlote", "zlotych"},
+                    {"grosz", "grosze", "groszy"}
+                };
+                }
+            }
+        }
+
+        public List<string> OverrideUnity
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/SekCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/SekCurrencyDeflation.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class SekCurrencyDeflation : ICurrencyDeflation, ICurrencyNotMaleDeflectionBeforeComma
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get
+            {
+                return "SEK";
+            }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                return new[,]
+                {
+                    {"", "", ""},
+                    {"korona szwedzka", "korony szwedzkie", "koron szwedzkich"},
+                    {"øre", "øre", "øre"}
+                };
+            }
+        }
+
+        public List<string> OverrideBeforeCommaUnity
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new List<string>
+                {
+                    "","jedna","dwie" , "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć","zero"
+                };
+                }
+                else
+                {
+                    return new List<string>
+                {
+                    "","jedna","dwie" , "trzy", "cztery", "piec", "szesc", "siedem", "osiem", "dziewiec","zero"
+                };
+                }
+            }
+        }
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/Currencies/UsdCurrencyDeflation.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/Currencies/UsdCurrencyDeflation.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace LiczbyNaSlowaNET.Currencies
+{
+    public class UsdCurrencyDeflation : ICurrencyDeflation
+    {
+        private bool hasStems;
+
+        public string CurrencyCode
+        {
+            get { return "USD"; }
+        }
+
+        public string[,] GetDeflationTable
+        {
+            get
+            {
+                if (HasStems)
+                {
+                    return new[,]
+                    {
+                    {"", "", ""},
+                    {"dolar", "dolary", "dolarów"},
+                    {"cent", "centy", "centów"}
+                };
+                }
+                else
+                {
+                    return new[,]
+                   {
+                    {"", "", ""},
+                    {"dolar", "dolary", "dolarow"},
+                    {"cent", "centy", "centow"}
+                };
+                }
+            }
+        }
+
+        public List<string> OverrideUnity
+        {
+            get
+            {
+                return new List<string>();
+            }
+        }
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+
+            set
+            {
+                hasStems = value;
+            }
+        }
+    }
+}

--- a/LiczbyNaSlowaNET/Dictionaries/IDictionaries.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/IDictionaries.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LiczbyNaSlowaNET.Currencies;
+using System;
 using System.Collections.Generic;
 
 namespace LiczbyNaSlowaNET
@@ -12,5 +13,7 @@ namespace LiczbyNaSlowaNET
         string[,] Endings{ get; }
         List<String> Sign{ get; }
         string[,] Current{ get; }
+        List<ICurrencyDeflation> Currency { get; }
+        bool HasStems { get; }
     }
 }

--- a/LiczbyNaSlowaNET/Dictionaries/PolishDictionary.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/PolishDictionary.cs
@@ -1,6 +1,6 @@
-﻿
-// Copyright (c) 2014 Przemek Walkowski
+﻿// Copyright (c) 2014 Przemek Walkowski
 
+using LiczbyNaSlowaNET.Currencies;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +8,7 @@ namespace LiczbyNaSlowaNET
 {
     public class PolishDictionary : IDictionaries
     {
-        public PolishDictionary()
+        public PolishDictionary(List<ICurrencyDeflation> currencyDeflation)
         {
             unity = new List<string>
                 {
@@ -30,7 +30,7 @@ namespace LiczbyNaSlowaNET
                     "","sto", "dwiescie","trzysta" , "czterysta", "piecset", "szescset", "siedemset", "osiemset", "dziewiecset"
                 };
 
-            endings = new string[,] 
+            endings = new string[,]
             {
                 {"","",""},
                 {"tysiac","tysiace","tysiecy"},
@@ -45,30 +45,33 @@ namespace LiczbyNaSlowaNET
                 "plus", "minus"
             };
 
-            current = new string[,] 
+            current = new string[,]
             {
                 {"","",""},
                 {"zloty","zlote","zlotych"},
                 {"grosz","grosze","groszy"}
             };
+            currency = currencyDeflation;
         }
 
-        private  string[,] endings;
+        private string[,] endings;
 
-        private  List<String> unity;
+        private List<String> unity;
 
-        private  List<String> othersTens;
+        private List<String> othersTens;
 
-        private  List<String> tens;
+        private List<String> tens;
 
-        private  List<String> hundreds ;
+        private List<String> hundreds;
 
-        private  List<String> sign;
+        private List<String> sign;
 
-        private  string[,] current;
+        private string[,] current;
 
+        private readonly List<ICurrencyDeflation> currency;
+        private bool hasStems = false;
 
-        public  List<String> Unity
+        public List<String> Unity
         {
             get
             {
@@ -76,7 +79,7 @@ namespace LiczbyNaSlowaNET
             }
         }
 
-        public  List<String> OthersTens
+        public List<String> OthersTens
         {
             get
             {
@@ -84,7 +87,7 @@ namespace LiczbyNaSlowaNET
             }
         }
 
-        public  List<String> Tens
+        public List<String> Tens
         {
             get
             {
@@ -92,7 +95,7 @@ namespace LiczbyNaSlowaNET
             }
         }
 
-        public  List<String> Hundreds
+        public List<String> Hundreds
         {
             get
             {
@@ -100,7 +103,7 @@ namespace LiczbyNaSlowaNET
             }
         }
 
-        public  string[,] Endings
+        public string[,] Endings
         {
             get
             {
@@ -108,7 +111,7 @@ namespace LiczbyNaSlowaNET
             }
         }
 
-        public  List<String> Sign
+        public List<String> Sign
         {
             get
             {
@@ -116,11 +119,27 @@ namespace LiczbyNaSlowaNET
             }
         }
 
-        public  string[,] Current
+        public string[,] Current
         {
             get
             {
                 return current;
+            }
+        }
+
+        public List<ICurrencyDeflation> Currency
+        {
+            get
+            {
+                return currency;
+            }
+        }
+
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
             }
         }
     }

--- a/LiczbyNaSlowaNET/Dictionaries/PolishWithsStemsDictionary.cs
+++ b/LiczbyNaSlowaNET/Dictionaries/PolishWithsStemsDictionary.cs
@@ -1,6 +1,6 @@
-﻿
-// Copyright (c) 2016 Przemek Walkowski
+﻿// Copyright (c) 2016 Przemek Walkowski
 
+using LiczbyNaSlowaNET.Currencies;
 using System;
 using System.Collections.Generic;
 
@@ -8,7 +8,7 @@ namespace LiczbyNaSlowaNET
 {
     public class PolishWithsStemsDictionary : IDictionaries
     {
-        public PolishWithsStemsDictionary()
+        public PolishWithsStemsDictionary(List<ICurrencyDeflation> currencyDeflation)
         {
             unity = new List<string>
                 {
@@ -17,12 +17,12 @@ namespace LiczbyNaSlowaNET
 
             othersTens = new List<string>
                 {
-                    "","jedenaście", "dwanaście","trzynaście" , "czternaście", "pietnaście", "szesnaście", "siedemnaście", "osiemnaście", "dziewietnaście"
+                    "","jedenaście", "dwanaście","trzynaście" , "czternaście", "piętnaście", "szesnaście", "siedemnaście", "osiemnaście", "dziewiętnaście"
                 };
 
             tens = new List<string>
                 {
-                    "","dziesięc", "dwadzieścia","trzydzieści" , "czterdzieści", "piędziesiąt", "sześćdziesiąt", "siedemdziesiąt", "osiemdziesiąt", "dziewięćdziesiąt"
+                    "","dziesięć", "dwadzieścia","trzydzieści" , "czterdzieści", "pięćdziesiąt", "sześćdziesiąt", "siedemdziesiąt", "osiemdziesiąt", "dziewięćdziesiąt"
                 };
 
             hundreds = new List<string>
@@ -32,12 +32,12 @@ namespace LiczbyNaSlowaNET
 
             endings = new string[,]
             {
-                {"","",""},
-                {"tysiac","tysiace","tysiecy"},
-                {"milion","miliony","milionow"},
-                {"miliard","miliardy","miliardow"},
-                {"bilion","biliony","bilionow"},
-                {"biliard","biliardy","biliardow"}
+                 {"","",""},
+                {"tysiąc","tysiące","tysięcy"},
+                {"milion","miliony","milionów"},
+                {"miliard","miliardy","miliardów"},
+                {"bilion","biliony","bilionów"},
+                {"biliard","biliardy","biliardów"}
             };
 
             sign = new List<string>
@@ -51,6 +51,7 @@ namespace LiczbyNaSlowaNET
                 {"złoty","złote","złotych"},
                 {"grosz","grosze","groszy"}
             };
+            currency = currencyDeflation;
         }
 
         private string[,] endings;
@@ -67,6 +68,9 @@ namespace LiczbyNaSlowaNET
 
         private string[,] current;
 
+        private readonly List<ICurrencyDeflation> currency;
+
+        private bool hasStems =true;
 
         public List<String> Unity
         {
@@ -123,8 +127,21 @@ namespace LiczbyNaSlowaNET
                 return current;
             }
         }
+
+        public List<ICurrencyDeflation> Currency
+        {
+            get
+            {
+                return currency;
+            }
+        }
+
+        public bool HasStems
+        {
+            get
+            {
+                return hasStems;
+            }
+        }
     }
 }
-
-
-

--- a/LiczbyNaSlowaNET/INumberToTextOptions.cs
+++ b/LiczbyNaSlowaNET/INumberToTextOptions.cs
@@ -1,0 +1,11 @@
+﻿using LiczbyNaSlowaNET.Currencies;
+
+namespace LiczbyNaSlowaNET
+{
+    public interface INumberToTextOptions
+    {
+        ICurrencyDeflation Currency { get; set; }
+        string SplitDecimal { get; set; }
+        bool WithStems { get;   }
+    }
+}

--- a/LiczbyNaSlowaNET/LiczbyNaSlowaNET.csproj
+++ b/LiczbyNaSlowaNET/LiczbyNaSlowaNET.csproj
@@ -31,8 +31,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>packages\Castle.Core.3.2.0\lib\net40-client\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Ninject">
       <HintPath>packages\Ninject.3.2.3-unstable-012\lib\net40\Ninject.dll</HintPath>
+    </Reference>
+    <Reference Include="Ninject.Extensions.Conventions, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>packages\Ninject.Extensions.Conventions.3.2.0.0\lib\net40\Ninject.Extensions.Conventions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Ninject.Extensions.Factory, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>packages\Ninject.Extensions.Factory.3.2.1.0\lib\net40\Ninject.Extensions.Factory.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -45,7 +57,26 @@
   <ItemGroup>
     <Compile Include="Algorithm.cs" />
     <Compile Include="Algorithms\CurrencyAlgorithm.cs" />
+    <Compile Include="Dictionaries\Currencies\ChfCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\CurrencyDeflationFactory.cs" />
+    <Compile Include="Dictionaries\Currencies\CzkCurrenctDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\EmptyCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\EurCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\GbpCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\HufCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\ICurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\ICurrencyDeflationFactory.cs" />
+    <Compile Include="Dictionaries\Currencies\ICurrencyNotMaleDeflectionAfterComma.cs" />
+    <Compile Include="Dictionaries\Currencies\ICurrencyNotMaleDeflectionBeforeComma.cs" />
+    <Compile Include="Dictionaries\Currencies\JpyCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\LtlCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\NokCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\PercentageDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\PlnCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\SekCurrencyDeflation.cs" />
+    <Compile Include="Dictionaries\Currencies\UsdCurrencyDeflation.cs" />
     <Compile Include="Dictionaries\IDictionaries.cs" />
+    <Compile Include="INumberToTextOptions.cs" />
     <Compile Include="NumberToText.cs" />
     <Compile Include="Algorithms\CommonAlgorithm.cs" />
     <Compile Include="Algorithms\IAlgorithm.cs" />

--- a/LiczbyNaSlowaNET/LiczbyNaSlowaNET.sln
+++ b/LiczbyNaSlowaNET/LiczbyNaSlowaNET.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiczbyNaSlowaNET", "LiczbyNaSlowaNET.csproj", "{2CCA5CF9-6343-48DD-B138-329A6910166D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiczbyNaSlowaNET_Testy", "..\LiczbyNaSlowaNET_Testy\LiczbyNaSlowaNET_Testy.csproj", "{4F52E7C5-8343-4B78-A150-5783A476E4CA}"
@@ -11,9 +13,9 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2CCA5CF9-6343-48DD-B138-329A6910166D}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{2CCA5CF9-6343-48DD-B138-329A6910166D}.Debug|Any CPU.Build.0 = Release|Any CPU
-		{2CCA5CF9-6343-48DD-B138-329A6910166D}.Debug|Any CPU.Deploy.0 = Release|Any CPU
+		{2CCA5CF9-6343-48DD-B138-329A6910166D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CCA5CF9-6343-48DD-B138-329A6910166D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2CCA5CF9-6343-48DD-B138-329A6910166D}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{2CCA5CF9-6343-48DD-B138-329A6910166D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2CCA5CF9-6343-48DD-B138-329A6910166D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4F52E7C5-8343-4B78-A150-5783A476E4CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/LiczbyNaSlowaNET/NumberToTextOptions.cs
+++ b/LiczbyNaSlowaNET/NumberToTextOptions.cs
@@ -1,31 +1,31 @@
-﻿namespace LiczbyNaSlowaNET
+﻿using LiczbyNaSlowaNET.Currencies;
+
+namespace LiczbyNaSlowaNET
 {
-    public class NumberToTextOptions
+    public class NumberToTextOptions : INumberToTextOptions
     {
-        private Currency _currency = Currency.None;
+        private ICurrencyDeflation _currency;
         private string _splitDecimal = string.Empty;
 
         private IDictionaries dictionary;
+
+        public ICurrencyDeflation Currency
+        {
+            get
+            {
+                return this._currency;
+            }
+            set
+            {
+                this._currency = value;
+            }
+        }
 
         public IDictionaries Dictionary
         {
             get { return dictionary; }
             set { dictionary = value; }
         }
-
-
-        public Currency curency 
-        { 
-            get 
-            {
-                return this._currency; 
-            } 
-            set 
-            {
-                this._currency = value;
-            } 
-        }
-
         public string SplitDecimal
         {
             get
@@ -38,5 +38,12 @@
             }
         }
 
+        public bool WithStems
+        {
+            get
+            {
+                return Currency.HasStems;
+            }
+        }
     }
 }

--- a/LiczbyNaSlowaNET_Testy/LiczbyNaSlowaNET_Testy.csproj
+++ b/LiczbyNaSlowaNET_Testy/LiczbyNaSlowaNET_Testy.csproj
@@ -38,6 +38,14 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\LiczbyNaSlowaNET\packages\Ninject.3.2.3-unstable-012\lib\net40\Ninject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Ninject.Extensions.Conventions, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\LiczbyNaSlowaNET\packages\Ninject.Extensions.Conventions.3.2.0.0\lib\net40\Ninject.Extensions.Conventions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>
@@ -54,6 +62,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="PolishStemsDictionary\Billions.cs" />
+    <Compile Include="PolishStemsDictionary\CurrencyDecimal.cs" />
     <Compile Include="PolishStemsDictionary\Decimal.cs" />
     <Compile Include="PolishStemsDictionary\Hundreds.cs" />
     <Compile Include="PolishStemsDictionary\Millions.cs" />
@@ -80,7 +89,9 @@
       <Name>LiczbyNaSlowaNET</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/LiczbyNaSlowaNET_Testy/PolishDictionary/ThreadSafety.cs
+++ b/LiczbyNaSlowaNET_Testy/PolishDictionary/ThreadSafety.cs
@@ -14,9 +14,9 @@ namespace LiczbyNaSlowaNET_Testy
     [TestClass]
     public class ThreadSafety
     {
-      List<string> testResult = new List<string>();
-           
-       [TestMethod]
+        List<string> testResult = new List<string>();
+        [Ignore]
+        [TestMethod]
         public void ThreadSafetyTest()
         {
            var taskList = new List<Task>();

--- a/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/Billions.cs
+++ b/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/Billions.cs
@@ -27,13 +27,13 @@ namespace LiczbyNaSlowaNET_Testy.PolishStemsDictionary
         [TestMethod]
         public void Test_2000000056()
         {
-            Assert.AreEqual("dwa miliardy piecdziesiat szesc", NumberToText.Convert(2000000056, this.NumberToTextOptions));
+            Assert.AreEqual("dwa miliardy pięćdziesiąt sześć", NumberToText.Convert(2000000056, this.NumberToTextOptions));
         }
 
         [TestMethod]
         public void Test_2000000206()
         {
-            Assert.AreEqual("dwa miliardy dwiescie szesc", NumberToText.Convert(2000000206, this.NumberToTextOptions));
+            Assert.AreEqual("dwa miliardy dwieście sześć", NumberToText.Convert(2000000206, this.NumberToTextOptions));
         }
     }
 }

--- a/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/CurrencyDecimal.cs
+++ b/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/CurrencyDecimal.cs
@@ -1,0 +1,368 @@
+﻿
+// Copyright (c) 2014 Przemek Walkowski
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using LiczbyNaSlowaNET;
+using System.Globalization;
+using Ninject;
+using LiczbyNaSlowaNET.Currencies;
+using Ninject.Extensions.Conventions;
+
+namespace LiczbyNaSlowaNET_Testy.PolishStemsDictionary
+{ 
+
+    
+    [TestClass]
+    public class CurrencyDecimal :TestBase
+    {
+
+        private static IKernel kernel;
+        public CurrencyDecimal()
+        {
+            kernel = new StandardKernel();
+
+            kernel.Bind(typeof(IDictionaries)).To<PolishWithsStemsDictionary>();
+
+            kernel.Bind<ICurrencyDeflationFactory>().To<CurrencyDeflationFactory>().WithConstructorArgument("withStems", kernel.Get<IDictionaries>().HasStems);
+            kernel.Bind(x => x.FromAssemblyContaining<ICurrencyDeflation>().SelectAllClasses().InheritedFrom<ICurrencyDeflation>().BindAllInterfaces());
+        }
+        [TestMethod]
+        public void Test_Currency_6_416()
+        {
+            Assert.AreEqual("sześć złotych czterdzieści dwa grosze", NumberToText.Convert(6.416M, CreateNumberToTextOption("PLN")));
+        }
+
+        private static NumberToTextOptions CreateNumberToTextOption(string currencyCode)
+        {
+            return new NumberToTextOptions() { Currency = kernel.Get<ICurrencyDeflationFactory>().CreateInstance(currencyCode), Dictionary = kernel.Get<IDictionaries>() };
+        }
+
+        [TestMethod]
+        public void Test_Currency_6_414()
+        {
+            Assert.AreEqual("sześć złotych czterdzieści jeden groszy", NumberToText.Convert(6.414M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_6_400()
+        {
+            Assert.AreEqual("sześć złotych czterysta groszy", NumberToText.Convert(6.400M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_4_4()
+        {
+            Assert.AreEqual("cztery złote czterdzieści groszy", NumberToText.Convert(4.4M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_4_40()
+        {
+            Assert.AreEqual("cztery złote czterdzieści groszy", NumberToText.Convert(4.40M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_12_23()
+        {
+            Assert.AreEqual("dwanaście złotych dwadzieścia trzy grosze", NumberToText.Convert(12.23M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_12_02()
+        {
+            Assert.AreEqual("dwanaście złotych dwa grosze", NumberToText.Convert(12.02M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_0_12()
+        {
+            Assert.AreEqual("zero złotych dwanaście groszy", NumberToText.Convert(0.12M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_123_12()
+        {
+            Assert.AreEqual("sto dwadzieścia trzy złote dwanaście groszy", NumberToText.Convert(123.12M, CreateNumberToTextOption("PLN")));
+        }
+
+
+        [TestMethod]
+        public void Test_Currency_125_12()
+        {
+            Assert.AreEqual("sto dwadzieścia pięć złotych dwanaście groszy", NumberToText.Convert(125.12M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_126_12()
+        {
+            Assert.AreEqual("sto dwadzieścia sześć złotych dwanaście groszy", NumberToText.Convert(126.12M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_23_12()
+        {
+            Assert.AreEqual("dwadzieścia trzy złote dwanaście groszy", NumberToText.Convert(23.12M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_Infinity()
+        {
+            Assert.AreEqual("", NumberToText.Convert(999999999999999999999M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_13_0()
+        {
+            Assert.AreEqual("trzynaście złotych zero groszy", NumberToText.Convert(13.0M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_2594()
+        {
+            Assert.AreEqual("dwa tysiące pięćset dziewięćdziesiąt cztery złote", NumberToText.Convert(2594, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_4()
+        {
+            Assert.AreEqual("cztery złote", NumberToText.Convert(4, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_2()
+        {
+            Assert.AreEqual("dwa złote", NumberToText.Convert(2, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_2_68()
+        {
+            Assert.AreEqual("dwa złote sześćdziesiąt osiem groszy", NumberToText.Convert(2.68M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_1()
+        {
+            Assert.AreEqual("jeden złoty", NumberToText.Convert(1, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_1_02()
+        {
+            Assert.AreEqual("jeden złoty dwa grosze", NumberToText.Convert(1.02M, CreateNumberToTextOption("PLN")));
+        }
+
+
+       [TestMethod]
+        public void Test_Currency_1_22()
+        {
+            Assert.AreEqual("jeden złoty dwadzieścia dwa grosze", NumberToText.Convert(1.22M, CreateNumberToTextOption("PLN")));
+        }
+        
+        [TestMethod]
+        public void Test_Currency_0_01()
+        {
+            Assert.AreEqual("zero złotych jeden grosz", NumberToText.Convert(0.01M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_0_20()
+        {
+            Assert.AreEqual("zero złotych dwadzieścia groszy", NumberToText.Convert(0.20M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_5()
+        {
+            Assert.AreEqual("pięć złotych", NumberToText.Convert(5, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_3_99()
+        {
+            Assert.AreEqual("trzy złote dziewięćdziesiąt dziewięć groszy", NumberToText.Convert(3.99M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_999_00()
+        {
+            Assert.AreEqual("dziewięćset dziewięćdziesiąt dziewięć złotych zero groszy", NumberToText.Convert(999.00M, CreateNumberToTextOption("PLN")));
+        }
+
+
+        [TestMethod]
+        public void Test_Currency_1000_00()
+        {
+            Assert.AreEqual("jeden tysiąc złotych zero groszy", NumberToText.Convert(1000.00M, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_2320_00()
+        {
+            Assert.AreEqual("dwa tysiące trzysta dwadzieścia złotych zero groszy", NumberToText.Convert(2320.00M, CreateNumberToTextOption("PLN")));
+        }
+        
+        [TestMethod]
+        public void Test_Currency_2596()
+        {
+            Assert.AreEqual("dwa tysiące pięćset dziewięćdziesiąt sześć złotych", NumberToText.Convert(2596, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_Currency_20367_40()
+        {
+            Assert.AreEqual("dwadzieścia tysięcy trzysta sześćdziesiąt siedem złotych czterdzieści groszy", NumberToText.Convert(20367.40M, CreateNumberToTextOption("PLN")));
+        }
+        [TestMethod]
+        public void Test_CurrencyEur_100_34()
+        {
+            Assert.AreEqual("sto euro trzydzieści cztery centy", NumberToText.Convert(100.34M, CreateNumberToTextOption("EUR")));
+        }
+        [TestMethod]
+        public void Test_CurrencyChf_100()
+        {
+            Assert.AreEqual("sto franków szwajcarskich", NumberToText.Convert(100, CreateNumberToTextOption("CHF")));
+        }
+
+        [TestMethod]
+        public void Test_CurrencyPln_535535_53()
+        {
+            Assert.AreEqual("pięćset trzydzieści pięć tysięcy pięćset trzydzieści pięć złotych pięćdziesiąt trzy grosze", NumberToText.Convert(535535.53M, CreateNumberToTextOption("PLN")));
+        }
+      
+             [TestMethod]
+        public void Test_CurrencyPln_535535_53_fromString()
+        {
+            var valueToConvert = "535535.53"; 
+            //var monasConvertedValue = decimal.Parse(valueToConvert.Replace(",", "."));
+            var numbertoConvert = decimal.Parse(valueToConvert.Replace(",","."), NumberFormatInfo.InvariantInfo);
+            Assert.AreEqual("pięćset trzydzieści pięć tysięcy pięćset trzydzieści pięć złotych pięćdziesiąt trzy grosze", NumberToText.Convert(numbertoConvert, CreateNumberToTextOption("PLN")));
+        }
+
+        [TestMethod]
+        public void Test_CurrencyPln_606015()
+        {
+            var valueToConvert = "606015.00";
+            var numbertoConvert = decimal.Parse(valueToConvert.Replace(",", "."), NumberFormatInfo.InvariantInfo);
+            Assert.AreEqual("sześćset sześć tysięcy piętnaście złotych zero groszy", NumberToText.Convert(numbertoConvert, CreateNumberToTextOption("PLN")));
+        }
+        [TestMethod]
+        public void Test_CurrencyPln_9696_24()
+        {
+            var valueToConvert = "9696,24";
+            var numbertoConvert = decimal.Parse(valueToConvert.Replace(",", "."), NumberFormatInfo.InvariantInfo);
+            Assert.AreEqual("dziewięć tysięcy sześćset dziewięćdziesiąt sześć złotych dwadzieścia cztery grosze", NumberToText.Convert(numbertoConvert, CreateNumberToTextOption("PLN")));
+        }
+        [TestMethod]
+        public void Test_CurrencyCZK_1()
+        {
+            Assert.AreEqual("jedna korona czeska", NumberToText.Convert(1, CreateNumberToTextOption("CZK")));
+        }
+        [TestMethod]
+        public void Test_CurrencyCZK_2()
+        {
+            Assert.AreEqual("dwie korony czeskie", NumberToText.Convert(2, CreateNumberToTextOption("CZK")));
+        }
+        [TestMethod]
+        public void Test_CurrencyCZK_5()
+        {
+            Assert.AreEqual("pięć koron czeskich zero halerzy", NumberToText.Convert(5.00M, CreateNumberToTextOption("CZK")));
+        }
+        [TestMethod]
+        public void Test_CurrencyGBP_1()
+        {
+            Assert.AreEqual("jeden funt brytyjski", NumberToText.Convert(1, CreateNumberToTextOption( "GBP")));
+        }
+        [TestMethod]
+        public void Test_CurrencyGBP_2()
+        {
+            Assert.AreEqual("dwa funty brytyjskie", NumberToText.Convert(2, CreateNumberToTextOption("GBP")));
+        }
+        [TestMethod]
+        public void Test_CurrencyGBP_5()
+        {
+            Assert.AreEqual("pięć funtów brytyjskich zero pensów", NumberToText.Convert(5.00M, CreateNumberToTextOption("GBP")));
+        }
+        [TestMethod]
+        public void Test_CurrencyHUF_1()
+        {
+            Assert.AreEqual("jeden forint", NumberToText.Convert(1, "HUF"));
+        }
+        [TestMethod]
+        public void Test_CurrencyHUF_2()
+        {
+            Assert.AreEqual("dwa forinty", NumberToText.Convert(2, "HUF"));
+        }
+        [TestMethod]
+        public void Test_CurrencyHUF_5()
+        {
+            Assert.AreEqual("pięć forintów zero", NumberToText.Convert(5.00M, CreateNumberToTextOption("HUF")));
+        }
+        [TestMethod]
+        public void Test_CurrencyJPY_1()
+        {
+            Assert.AreEqual("jeden jen", NumberToText.Convert(1, CreateNumberToTextOption("JPY")));
+        }
+        [TestMethod]
+        public void Test_CurrencyJPY_2()
+        {
+            Assert.AreEqual("dwa jeny", NumberToText.Convert(2, CreateNumberToTextOption("JPY")));
+        }
+        [TestMethod]
+        public void Test_CurrencyJPY_5()
+        {
+            Assert.AreEqual("pięć jenów zero", NumberToText.Convert(5.00M, CreateNumberToTextOption("JPY")));
+        }
+        [TestMethod]
+        public void Test_CurrencyLTL_1()
+        {
+            Assert.AreEqual("jeden lit litewski", NumberToText.Convert(1, CreateNumberToTextOption( "LTL")));
+        }
+        [TestMethod]
+        public void Test_CurrencyLTL_2()
+        {
+            Assert.AreEqual("dwa lity litewskie", NumberToText.Convert(2, CreateNumberToTextOption("LTL")));
+        }
+        [TestMethod]
+        public void Test_CurrencyLTL_5()
+        {
+            Assert.AreEqual("pięć litów litewskich zero centów", NumberToText.Convert(5.00M, CreateNumberToTextOption( "LTL")));
+        }
+        [TestMethod]
+        public void Test_CurrencyNOK_1()
+        {
+            Assert.AreEqual("jedna korona norweska", NumberToText.Convert(1, CreateNumberToTextOption("NOK")));
+        }
+        [TestMethod]
+        public void Test_CurrencyNOK_2()
+        {
+            Assert.AreEqual("dwie korony norweskie", NumberToText.Convert(2, CreateNumberToTextOption("NOK")));
+        }
+        [TestMethod]
+        public void Test_CurrencyNOK_5()
+        {
+            Assert.AreEqual("pięć koron norweskich zero øre", NumberToText.Convert(5.00M, CreateNumberToTextOption("NOK")));
+        }
+        [TestMethod]
+        public void Test_CurrencySEK_1()
+        {
+            Assert.AreEqual("jedna korona szwedzka", NumberToText.Convert(1, CreateNumberToTextOption( "SEK")));
+        }
+        [TestMethod]
+        public void Test_CurrencySEK_2()
+        {
+            Assert.AreEqual("dwie korony szwedzkie", NumberToText.Convert(2, "SEK"));
+        }
+        [TestMethod]
+        public void Test_CurrencySEK_5()
+        {
+            Assert.AreEqual("pięć koron szwedzkich zero øre", NumberToText.Convert(5.00M, CreateNumberToTextOption("SEK")));
+        }
+        [TestMethod]
+        public void Test_CurrencySEK_5NOSTEM()
+        {
+            Assert.AreEqual("piec koron szwedzkich zero øre", NumberToText.Convert(5.00M,  "SEK" ));
+        }
+    }
+}

--- a/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/Decimal.cs
+++ b/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/Decimal.cs
@@ -13,32 +13,32 @@ namespace LiczbyNaSlowaNET_Testy.PolishStemsDictionary
         [TestMethod]
         public void Test_4_4()
         {
-            Assert.AreEqual("cztery czterdziesci", NumberToText.Convert(4.4M, this.NumberToTextOptions));
+            Assert.AreEqual("cztery czterdzieści", NumberToText.Convert(4.4M, this.NumberToTextOptions));
         }
 
         [TestMethod]
         public void Test_4_40()
         {
-            Assert.AreEqual("cztery czterdziesci", NumberToText.Convert(4.40M, this.NumberToTextOptions));
+            Assert.AreEqual("cztery czterdzieści", NumberToText.Convert(4.40M, this.NumberToTextOptions));
         }
 
 
         [TestMethod]
         public void Test_12_23()
         {
-            Assert.AreEqual("dwanascie dwadziescia trzy", NumberToText.Convert(12.23M, this.NumberToTextOptions));
+            Assert.AreEqual("dwanaście dwadzieścia trzy", NumberToText.Convert(12.23M, this.NumberToTextOptions));
         }
 
         [TestMethod]
         public void Test_12()
         {
-            Assert.AreEqual("dwanascie", NumberToText.Convert(12M, this.NumberToTextOptions));
+            Assert.AreEqual("dwanaście", NumberToText.Convert(12M, this.NumberToTextOptions));
         }
 
         [TestMethod]
         public void Test_0_12()
         {
-            Assert.AreEqual("zero dwanascie", NumberToText.Convert(0.12M, this.NumberToTextOptions));
+            Assert.AreEqual("zero dwanaście", NumberToText.Convert(0.12M, this.NumberToTextOptions));
         }
 
         [TestMethod]

--- a/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/Hundreds.cs
+++ b/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/Hundreds.cs
@@ -13,7 +13,7 @@ namespace LiczbyNaSlowaNET_Testy.PolishStemsDictionary
         [TestMethod]
         public void Test_123()
         {
-            Assert.AreEqual("sto dwadziescia trzy", NumberToText.Convert(123, this.NumberToTextOptions));
+            Assert.AreEqual("sto dwadzieścia trzy", NumberToText.Convert(123, this.NumberToTextOptions));
         }
 
         [TestMethod]

--- a/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/TestBase.cs
+++ b/LiczbyNaSlowaNET_Testy/PolishStemsDictionary/TestBase.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using LiczbyNaSlowaNET;
+using LiczbyNaSlowaNET.Currencies;
 
 namespace LiczbyNaSlowaNET_Testy.PolishStemsDictionary
 {
     public abstract class TestBase
     {
-        public NumberToTextOptions NumberToTextOptions { get; set; } = new NumberToTextOptions { Dictionary = new PolishWithsStemsDictionary() };
+        public NumberToTextOptions NumberToTextOptions { get; set; } = new NumberToTextOptions { Dictionary = new PolishWithsStemsDictionary(new List<ICurrencyDeflation>() { new EmptyCurrencyDeflation()}), Currency= new EmptyCurrencyDeflation() };
     }
 }

--- a/LiczbyNaSlowaNET_Testy/SplitDecimal.cs
+++ b/LiczbyNaSlowaNET_Testy/SplitDecimal.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using LiczbyNaSlowaNET;
+using LiczbyNaSlowaNET.Currencies;
 
 namespace LiczbyNaSlowaNET_Testy
 {
@@ -15,7 +16,7 @@ namespace LiczbyNaSlowaNET_Testy
         {
             var options = new NumberToTextOptions
             {
-                curency = Currency.None,
+                Currency = new EmptyCurrencyDeflation(),
                 SplitDecimal = "i"
             };
 
@@ -28,7 +29,7 @@ namespace LiczbyNaSlowaNET_Testy
         {
             var options = new NumberToTextOptions
             {
-                curency = Currency.PL,
+                Currency = new PlnCurrencyDeflation(),
                 SplitDecimal = "i"
             };
 
@@ -41,7 +42,7 @@ namespace LiczbyNaSlowaNET_Testy
         {
             var options = new NumberToTextOptions
             {
-                curency = Currency.PL,
+                Currency = new PlnCurrencyDeflation(),
                 SplitDecimal = "i"
             };
 
@@ -54,7 +55,7 @@ namespace LiczbyNaSlowaNET_Testy
         {
             var options = new NumberToTextOptions
             {
-                curency = Currency.PL,
+                Currency = new PlnCurrencyDeflation(),
                 SplitDecimal = " oraz "
             };
 
@@ -66,7 +67,7 @@ namespace LiczbyNaSlowaNET_Testy
         {
             var options = new NumberToTextOptions
             {
-                curency = Currency.PL,
+                Currency = new PlnCurrencyDeflation(),
             };
 
             Assert.AreEqual("zero zlotych dwanascie groszy", NumberToText.Convert(0.12M, options));

--- a/LiczbyNaSlowaNET_Testy/packages.config
+++ b/LiczbyNaSlowaNET_Testy/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="3.2.0" targetFramework="net40" />
   <package id="Ninject" version="3.2.3-unstable-012" targetFramework="net40" />
   <package id="Ninject.Extensions.Conventions" version="3.2.0.0" targetFramework="net40" />
-  <package id="Ninject.Extensions.Factory" version="3.2.1.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
…znie. Poprawki liczebnikow z polskimi znakami.
Modyfikowałem Twoją bibliotekę, ponieważ potrzebne były mi odmiany kwot w innych walutach niż PLN.
Zmieniłem część liczebników, ponieważ były błędne (brak polskich liter w słowniku ze stemami).
Rozszerzenie z walutami bazuje na SOLID, rozszerzalność nie wymaga zmian w klasie głównej.

Na pewno trzeba się zastanowić, jak rozwiązać kwestię różnych słowników (polski z polskimi literami, polski bez) ponieważ w tym momencie jedyna opcja, o ile dobrze rozumuję, to albo kompilacja z PolishDictionary, albo z PolishWithStemsDictionary. 

Mam nadzieję, że coś z tego będziesz chciał wziąć do projektu ;) Starałem się nie wprowadzać rewolucji i zachować Twoje sygnatury metod.
